### PR TITLE
Fix some problems in syllable.json

### DIFF
--- a/src/parser/syllable.json
+++ b/src/parser/syllable.json
@@ -155,7 +155,7 @@
     "eng": true,
     "er": false,
     "i": true,
-    "ia": false,
+    "ia": true,
     "ian": true,
     "iang": false,
     "iao": true,
@@ -385,15 +385,15 @@
     "ou": true,
     "u": true,
     "ua": false,
-    "uai": true,
-    "uan": false,
+    "uai": false,
+    "uan": true,
     "uang": false,
-    "ue": true,
+    "ue": false,
     "ui": false,
     "un": true,
     "uo": true,
     "v": true,
-    "ve": false
+    "ve": true
   },
   "m": {
     "a": true,


### PR DESCRIPTION
In general, the allowed syllables in `syllable.json` should agree with the pinyin in the dictionaries, e.g. `"lve"` instead of `"lue"`. There are still some syllables allowed in `syllable.json` but not in the current dictionary, but I let them be since they don't seem to conflict with anything else, and could appear in a larger dictionary.